### PR TITLE
Fix script read missing last line of plugins.txt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,7 @@ wp core install --url=$url --title="$title" --admin_user=$adminlogin --admin_ema
 
 # Plugins install
 bot "J'installe les plugins à partir de la liste"
-while read line
+while read line || [ -n "$line" ]
 do
 	bot "-> Plugin $line"
     wp plugin install $line --activate


### PR DESCRIPTION
Lorsque le fichier plugins.txt ne contient pas de nouvelle ligne en fin de fichier, celle-ci n'est pas lue et le dernier plugin n'est donc pas installé.

Fix D'après http://stackoverflow.com/a/12916758
